### PR TITLE
Url params persists in top nav bar

### DIFF
--- a/alerts.html
+++ b/alerts.html
@@ -59,7 +59,7 @@ $.getJSON( root_url + "/data/getvalues", function( data ) {
                                 showall = 1;
                             }
                           
-                            location.href = "?rev="+rev+"&test="+test+"&platform="+platform+"&showAll="+showall+"&testIndex="+testIndex+"&platIndex="+platIndex;
+                            location.href = "?rev="+rev+"&showAll="+showall+"&testIndex="+testIndex+"&platIndex="+platIndex;
                                     
                     });
 });


### PR DESCRIPTION
Hi Joel,
              Now the url params are shown in the top nav bar, even when the values are set manually in the url. Please do have a look and review the code. Please let me know of the results.

Thanks.
