### PR TITLE
Make root_url in various js scripts host agnostic

### DIFF
--- a/js/AddCommentUI.js
+++ b/js/AddCommentUI.js
@@ -5,7 +5,7 @@
 
 var alertID = '';
 
-var root_url = 'http://54.215.155.53:8080';
+var root_url = window.location.protocol + '//' + window.location.host;
 
 var AddCommentUI = {
 

--- a/js/alerts.js
+++ b/js/alerts.js
@@ -1,4 +1,4 @@
-var root_url = 'http://54.215.155.53:8080';
+var root_url = window.location.protocol + '//' + window.location.host;
 
 $.getJSON( root_url + "/getvalues", function( data ) {
 

--- a/report.html
+++ b/report.html
@@ -10,7 +10,7 @@
     <script language="javascript" type="text/javascript" src="js/flot/jquery.flot.pie.js"></script>
      <script language="javascript" type="text/javascript" src="js/flot/jquery.flot.categories.js"></script>
     <script type="text/javascript">
-var root_url = 'http://54.215.155.53:8080';
+var root_url = window.location.protocol + '//' + window.location.host;
 var collection = [0,0,0,0,0,0];
 var count = [];
 var bug_count = [];


### PR DESCRIPTION
I've gone through and made root_url generic in the three locations where it occurs in alert_manager. This change will make requests to the alert_manager instance running in docker, or on a remote server instead of polling the remote instance at http://54.215.155.53:8080
