### PR TITLE
add conditional to check showall is really toggled

### DIFF
--- a/js/alerts.js
+++ b/js/alerts.js
@@ -263,7 +263,9 @@ function loadAllAlerts(showall, rev, test, platform, current) {
                 $(document.getElementById(keyrev + "-hdr")).html("");
             }
         }
-        addMergedLinks(showall);
+	if (showall === 1) {
+            addMergedLinks(showall);
+        }
         AddCommentUI.init();
         AddDuplicateUI.init();
         AddBugUI.init();


### PR DESCRIPTION
I think this one conditional eliminates a huge amount of slowdowns. On initial page load, showall is not set, but an XHR request still fires to /mergedids. This conditional prevents that.

The same request fires on requests to /alerts.html?rev=foobar, which most definitely does not need all 127 days worth of raw json to show a single alert, so this conditional stops that request too.

Thoughts? I hope that I understand how and why showall is used - my understanding is that it is mainly a way to toggle showing expired alerts in the main /alerts.html view.
