### PR TITLE
Revision is obtained from the URL instead of the dropdown

### DIFF
--- a/alerts.html
+++ b/alerts.html
@@ -10,11 +10,11 @@
     <script src="js/AddCommentUI.js"></script>
     <script src="js/alerts.js"></script>
     <script type="text/javascript">
-        function addMergedAlertToUI(tbl, alert, showall) {
+        function addMergedAlertToUI(tbl, alert, showall, rev) {
             var fields = ["date", "branch", "test", "platform", "percent", "reference", "investigate", "status"]    //fields have been changed to adjust the cell elements.
-            var e = document.getElementById("rev");
-            var revision = e.options[e.selectedIndex].value; 
-            document.getElementById("jump").innerHTML="<h5><a href="+root_url+"/alerts.html?rev="+revision+"&table=1>Toggle View</a></h5>";
+            //var e = document.getElementById("rev");
+            //var revision = e.options[e.selectedIndex].value; 
+            document.getElementById("jump").innerHTML="<h5><a href="+root_url+"/alerts.html?rev="+rev+"&table=1>Toggle View</a></h5>";
             var cname = "data";
             if (alert["mergedfrom"] != "" && alert["mergedfrom"] != undefined) {
                 cname = "mergeddata";

--- a/js/alerts.js
+++ b/js/alerts.js
@@ -213,8 +213,8 @@ function updateTbplURL(alertid, tbplurl) {
     AddTbplUI.openTbplBox(alertid, tbplurl);
 }
 
-function addAlertToUI(tbl, alert, showall) {
-    addMergedAlertToUI(tbl, alert, showall);
+function addAlertToUI(tbl, alert, showall, rev) {
+    addMergedAlertToUI(tbl, alert, showall, rev);
 }
 
 
@@ -287,7 +287,7 @@ function loadAllAlertsTable(showall, rev, test, platform, current, show_improvem
                 var row0 = table.insertRow(1);
                 rowlist.push(row0);
                 var cell0 = row0.insertCell(0);
-                cell0.innerHTML ="<b> "+data[i]["test"]+" </b>";
+                cell0.innerHTML ="<b>&nbsp;"+data[i]["test"]+"&nbsp;</b>";
             }
         }
         for (var y=0;y<tests.length;y++) {
@@ -350,7 +350,7 @@ function loadAllAlerts(showall, rev, test, platform, current) {
                 $(document.getElementById(keyrev + "-hdr")).html("<a href=?rev=" + keyrev + "&showall=1&testIndex=0&platIndex=0><h3>" + keyrev + "</h3></a>");
                 tbl = document.getElementById(keyrev + "-tbl");
             }
-            var r = addAlertToUI(tbl, alerts[alert], showall);
+            var r = addAlertToUI(tbl, alerts[alert], showall, rev);
             if ($(document.getElementById(keyrev + '-tbl')).find('tr').size() == 0) {
                 $(document.getElementById(keyrev + "-hdr")).html("");
             }


### PR DESCRIPTION
Now I am taking the revision from the URL of the list view instead of the dropdown list. Hopefully this would fix the problem of blank revisions.

My Logic for doing so : If the listview of the individual revisions is loading, that means the revision is correctly being passed through the URL so taking the value from the URL should not produce any blank results.

Once this is sorted out, I will be deleting the commented out code and fixing the other issues.
