### PR TITLE
List treeherder-client v2.0.1 as an explicit dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,15 @@
 pymysql
 Flask==0.10.1
 flask-compress
-requests==2.3.0
+requests==2.9.1
 pyLibrary==0.3.14288
 mozci>=0.13.1
+treeherder-client==2.0.1
+
+# Required by treeherder-client
+mohawk==0.3.1
+requests-hawk==1.0.0
+six==1.10.0
 
 # optional package for pre-commit hook
 flake8==2.2.2


### PR DESCRIPTION
treeherder-client is not listed in the requirements file directly, even though Alert Manager uses it. (It's installed by chance via mozci's dependency on treeherder-client.)

To both more reliably ensure treeherder-client is installed, and to update any installed version to the latest, treeherder-client and its sub-dependencies have been added to the requirements file.

treeherder-client also requires requests >= 2.4.3 (since it uses the json POST parameter), so requests has also been updated to the latest release (keeping it up to date is always recommended, since it bundles newer versions of certifi etc).

Notably treeherder-client v2.0.1 includes an API URL fix that will prevent 404s once non-canonical Treeherder API URLs are disabled in bug 1234233.